### PR TITLE
Make logdump action output path configurable

### DIFF
--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -12,7 +12,7 @@ runs:
       id: mkdir
       shell: bash
       run: |
-        LOG_DIR="tmp_logs"
+        LOG_DIR="${${{ env.LOGDUMP_OUTPUT_DIR }}:-tmp_logs_$GITHUB_JOB}"
         echo "log-dir=$(echo $LOG_DIR)" >> $GITHUB_OUTPUT
         mkdir $LOG_DIR
 


### PR DESCRIPTION
Currently, the logdump action output path is hard-coded. Running this action twice in the same CI causes these actions to overwrite each others logs.

With this commit, the path can now be configured by setting the `$LOGDUMP_OUTPUT_DIR` env variable in a workflow. If it is not set the path will fall-back to `tmp_logs_$GITHUB_JOB` with $GITHUB_JOB being the unique id of the current running job.

Closes #95